### PR TITLE
Patch check for error message on add link to group response

### DIFF
--- a/src/requests/addLinkToGroup.js
+++ b/src/requests/addLinkToGroup.js
@@ -12,6 +12,13 @@ const addLinkToGroup = async (url: string, TSID: string | number) => {
     linkCreatorSetting: 'Simple'
   })
   const [ linkResponse ] = res.body.LinkResponses
+
+  if (linkResponse.ErrorMessage && linkResponse.ErrorMessage !== '') {
+    const error = new Error('Genius API could not generate a code, but still came back with 200')
+    error.originalMessage = linkResponse.ErrorMessage
+    throw error
+  }
+
   return linkResponse.NewLink.ShortUrlCode
 }
 

--- a/src/requests/addLinkToGroup.spec.js
+++ b/src/requests/addLinkToGroup.spec.js
@@ -24,3 +24,19 @@ test(`create a new tracked link`, async (t) => {
 
   t.is(shortcode, SHORTCODE)
 })
+
+test('If genius replies with 200 but LinkResponses contains an error message, throw an error that we can easily see', async (t) => {
+  const LINK = 'http://app.mish.guru'
+  const SHORTCODE = 'b823f2'
+  const GROUP_ID = 99870
+
+  nock('https://api.geni.us')
+    .post('/v1/links/add')
+    .reply(200, {
+      LinkResponses: [{
+        ErrorMessage: 'genius message'
+      }]
+    })
+
+  await t.throws(addLinkToGroup(LINK, GROUP_ID), 'Genius API could not generate a code, but still came back with 200')
+})

--- a/src/requests/addLinkToGroup.spec.js
+++ b/src/requests/addLinkToGroup.spec.js
@@ -27,7 +27,6 @@ test(`create a new tracked link`, async (t) => {
 
 test('If genius replies with 200 but LinkResponses contains an error message, throw an error that we can easily see', async (t) => {
   const LINK = 'http://app.mish.guru'
-  const SHORTCODE = 'b823f2'
   const GROUP_ID = 99870
 
   nock('https://api.geni.us')


### PR DESCRIPTION
If Genius doesn't like the URL you want to add to a group, it still replies with a 200, which implies success.

However, this 200 response will not have the `NewLink` property we expect, but will have a non-blank string value in the `ErrorMessage` property.

Like so:
```JSON
{
  "LinkResponses": [
    {
      "ErrorMessage": "Please check the formatting of your link: Invalid URI: The format of the URI could not be determined.",
      "Code": "",
      "ItunesMetadataJsonUrl": "",
      "ItemMetadataJson": ""
    }
  ],
  "ResponseStatus": {},
  "Request": {
    "Url": "mish.guru",
    "TSID": 71384,
    "SkipAffiliateRedirect": 0,
    "BulkMode": 0,
    "Domain": "mish.gr",
    "Note": "",
    "ApplePreference": 0,
    "LinkCreatorSetting": "Simple"
  }
}
```

It took me a wee while to work out that this was the problem, so I thought I'd put in handling for this that throws the kind of descriptive error that I would have liked to see.