### PR TITLE
Add support for baseCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const groupId = 12345
 
 addLinkToGroup(url, groupId)
   .then((result) => {
-    // result: { id: 'vCHktm', shortcode: 'h4o0n' }
+    // result: { id: 'vCHktm', code: 'h4o0n' }
   })
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ initGeniusLink({
   secret: process.env.GENIUSLINK_API_SECRET,
 })
 
-getTotalLinkClicks('a1b2c3')
+getTotalLinkClicks('vCHktm')
   .then(console.log)
 ```
 
@@ -66,9 +66,8 @@ const url = 'https://mish.guru'
 const groupId = 12345
 
 addLinkToGroup(url, groupId)
-  .then((shortcode) => {
-    // shortcode === '0zs3at'
-    ...
+  .then((result) => {
+    // result: { id: 'vCHktm', shortcode: 'h4o0n' }
   })
 ```
 
@@ -79,9 +78,9 @@ addLinkToGroup(url, groupId)
 ```javascript
 import { getTotalLinkClicks } from '@mishguru/geniuslink'
 
-const shortcode = 'r93n5'
+const id = 'vCHktm'
 
-getTotalLinkClicks(shortcode)
+getTotalLinkClicks(id)
   .then((count) => {
     // count === 472
     ...

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,8 +9,8 @@ class GroupNameCharLimitExceeded extends ExtendableError {
 }
 
 class AddLinkToGroupFailed extends ExtendableError {
-  public constructor () {
-    super('Genius API could not generate a code, but still came back with 200')
+  public constructor (message: string) {
+    super(`Failed to generate a shortcode using Genius API: ${message}`)
   }
 }
 

--- a/src/requests/addLinkToGroup.spec.ts
+++ b/src/requests/addLinkToGroup.spec.ts
@@ -7,20 +7,25 @@ import addLinkToGroup from './addLinkToGroup'
 
 test('create a new tracked link', async (t) => {
   const LINK = 'http://app.mish.guru'
-  const SHORTCODE = 'a823e1'
   const GROUP_ID = 12345
+  const SHORT_CODE = 'shortcode'
+  const BASE_CODE ='basecode'
 
   nock('https://api.geni.us')
     .post('/v3/shorturls')
     .reply(200, {
       shortUrl: {
-        code: SHORTCODE,
+        code: SHORT_CODE,
+        baseCode: BASE_CODE,
       },
     })
 
-  const shortcode = await addLinkToGroup(LINK, GROUP_ID)
+  const result = await addLinkToGroup(LINK, GROUP_ID)
 
-  t.is(shortcode, SHORTCODE)
+  t.deepEqual(result, {
+    id: BASE_CODE,
+    shortcode: SHORT_CODE,
+  })
 })
 
 test('throw error if code is not returned', async (t) => {
@@ -32,6 +37,7 @@ test('throw error if code is not returned', async (t) => {
     .reply(200, {
       shortUrl: {
         code: null,
+        baseCode: null,
       },
     })
 

--- a/src/requests/addLinkToGroup.spec.ts
+++ b/src/requests/addLinkToGroup.spec.ts
@@ -9,7 +9,7 @@ test('create a new tracked link', async (t) => {
   const LINK = 'http://app.mish.guru'
   const GROUP_ID = 12345
   const SHORT_CODE = 'shortcode'
-  const BASE_CODE ='basecode'
+  const BASE_CODE = 'basecode'
 
   nock('https://api.geni.us')
     .post('/v3/shorturls')

--- a/src/requests/addLinkToGroup.spec.ts
+++ b/src/requests/addLinkToGroup.spec.ts
@@ -24,7 +24,7 @@ test('create a new tracked link', async (t) => {
 
   t.deepEqual(result, {
     id: BASE_CODE,
-    shortcode: SHORT_CODE,
+    code: SHORT_CODE,
   })
 })
 

--- a/src/requests/addLinkToGroup.ts
+++ b/src/requests/addLinkToGroup.ts
@@ -14,12 +14,16 @@ const addLinkToGroup = async (url: string, groupId: string | number) => {
   })
 
   const code = R.path(['body', 'shortUrl', 'code'], res)
+  const baseCode = R.path(['body', 'shortUrl', 'baseCode'], res)
 
-  if (code == null) {
-    throw new AddLinkToGroupFailed()
+  if (code == null || baseCode == null) {
+    throw new AddLinkToGroupFailed('Either code and/or baseCode was not available!')
   }
 
-  return code
+  return {
+    id: baseCode,
+    shortcode: code
+  }
 }
 
 export default addLinkToGroup

--- a/src/requests/addLinkToGroup.ts
+++ b/src/requests/addLinkToGroup.ts
@@ -17,12 +17,14 @@ const addLinkToGroup = async (url: string, groupId: string | number) => {
   const id = R.path(['body', 'shortUrl', 'baseCode'], res)
 
   if (id == null || code == null) {
-    throw new AddLinkToGroupFailed('Either code and/or baseCode was not available!')
+    throw new AddLinkToGroupFailed(
+      'Either code and/or baseCode was not available!',
+    )
   }
 
   return {
     id,
-    code
+    code,
   }
 }
 

--- a/src/requests/addLinkToGroup.ts
+++ b/src/requests/addLinkToGroup.ts
@@ -14,15 +14,15 @@ const addLinkToGroup = async (url: string, groupId: string | number) => {
   })
 
   const code = R.path(['body', 'shortUrl', 'code'], res)
-  const baseCode = R.path(['body', 'shortUrl', 'baseCode'], res)
+  const id = R.path(['body', 'shortUrl', 'baseCode'], res)
 
-  if (code == null || baseCode == null) {
+  if (id == null || code == null) {
     throw new AddLinkToGroupFailed('Either code and/or baseCode was not available!')
   }
 
   return {
-    id: baseCode,
-    shortcode: code
+    id,
+    code
   }
 }
 


### PR DESCRIPTION
The `addLinkToGroup` function now returns an object.

```
{
  id: "this is the base code",
  code: "this is the short code"
}
```